### PR TITLE
Format cablegram in Book 2, Part 3, Chapter 3

### DIFF
--- a/src/epub/text/chapter-2-3-3.xhtml
+++ b/src/epub/text/chapter-2-3-3.xhtml
@@ -12,7 +12,7 @@
 				<p epub:type="title">Richmond Park</p>
 			</hgroup>
 			<p>On the afternoon that Soames crossed to France a cablegram was received by Jolyon at Robin Hill:</p>
-			<blockquote>
+			<blockquote class="telegram" epub:type="z3998:letter">
 				<p>“Your son down with enteric no immediate danger will cable again.”</p>
 			</blockquote>
 			<p>It reached a household already agitated by the imminent departure of June, whose berth was booked for the following day. She was, indeed, in the act of confiding Eric Cobbley and his family to her father’s care when the message arrived.</p>


### PR DESCRIPTION
The `local.css` file already had the CSS for telegram styling, so I didn't have to add it in.